### PR TITLE
Explicitly pass handles on windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to `self-replace` are documented here.
 
+## 1.3.4
+
+- Explicitly pass the process handle on Windows simplifying the implementation.
+- Change the dummy command to use on windows away from `ping.exe` to `cmd.exe`.
+
 ## 1.3.3
 
 - Avoid the use of `atexit` and spawn immediately.  This has the advantage

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,13 +18,10 @@ tempfile = "3.5.0"
 fastrand = "1.9.0"
 windows-sys = { version = "0.48.0", features = [
     "Win32_Foundation",
-    "Win32_Security",
     "Win32_Storage_FileSystem",
-    "Win32_System_Diagnostics_ToolHelp",
     "Win32_System_Environment",
     "Win32_System_LibraryLoader",
     "Win32_System_Memory",
     "Win32_System_Threading",
-    "Win32_System_SystemServices",
     "Win32_UI_Shell",
 ] }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -69,12 +69,11 @@
 //! This library contains a special glue code that detects this copy of the executable
 //! and does nothing else but waiting for the parent to quit and to then delete the
 //! parent executable.  There is an extra hack in there in that it spawns another system
-//! executable that stays alive until after we shut down (in our case `ping`) to make
-//! the self deletion of the copy work.  This is necessary because our running executable
-//! must not be the last user of that file handle as otherwise the deletion
-//! won't work as the executable still cannot be deleted.  Presumably this is
-//! because `CreateProcess` and friends do not open the executable with
-//! `FILE_FLAG_DELETE_ON_CLOSE`.
+//! executable that stays alive until after we shut down to make the self deletion of
+//! the copy work.  This is necessary because our running executable must not be the
+//! last user of that file handle as otherwise the deletion won't work as the
+//! executable still cannot be deleted.  Presumably this is because `CreateProcess`
+//! and friends do not open the executable with `FILE_FLAG_DELETE_ON_CLOSE`.
 //!
 //! **Special note on Windows:** the system will attempt to run the parent deletion logic
 //! if the executable has the suffix `.__selfdelete__.exe`.  This means if you
@@ -100,7 +99,8 @@
 //! The third, and somewhat official solution is to use `MOVEFILE_DELAY_UNTIL_REBOOT`
 //! with `MoveFileEx`.  This causes windows to store an entry in the registry and
 //! will perform the delete / move on restart.  This means that if a restart of the
-//! machine does not happen, no cleanup is performed.
+//! machine does not happen, no cleanup is performed.  It also is a privileged
+//! operation that is not available to all user accounts.
 //!
 //! ## Limitations
 //!


### PR DESCRIPTION
This passes the parent process handle explicitly addressing some of the comments in #4. It also changes away from `ping.exe` to `cmd.exe` as ping might not be available on all machines (even if unlikely).

Refs #9