### PR TITLE
Pass copy of cmdline to CreateProcessA

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to `self-replace` are documented here.
 
 - Explicitly pass the process handle on Windows simplifying the implementation.
 - Change the dummy command to use on windows away from `ping.exe` to `cmd.exe`.
+- More correctly invoke `CreateProcessA` on Windows.
 
 ## 1.3.3
 


### PR DESCRIPTION
While windows only modifies the pointers for the wide functions, it really should be called correctly. 