### PR TITLE
Fix self_replace through symbolic links on macOS

### DIFF
--- a/examples/replaces-itself.rs
+++ b/examples/replaces-itself.rs
@@ -1,7 +1,7 @@
 use std::env::consts::EXE_EXTENSION;
 
 fn main() {
-    let new_executable = std::env::current_exe()
+    let new_executable = std::fs::read_link(std::env::current_exe().unwrap())
         .unwrap()
         .with_file_name("hello")
         .with_extension(EXE_EXTENSION);

--- a/src/unix.rs
+++ b/src/unix.rs
@@ -11,7 +11,10 @@ pub fn self_delete() -> Result<(), io::Error> {
 }
 
 pub fn self_replace(new_executable: &Path) -> Result<(), io::Error> {
-    let exe = env::current_exe()?;
+    let mut exe = env::current_exe()?;
+    if exe.is_symlink() {
+        exe = fs::read_link(exe)?;
+    }
     let old_permissions = exe.metadata()?.permissions();
 
     let prefix = if let Some(hint) = exe.file_stem().and_then(|x| x.to_str()) {


### PR DESCRIPTION
This change supports `self_replace` if the binary being invoked is called through a symbolic link on certain platforms including macOS.

Prior to this change on macOS if the binary was invoked through a symlink, the path returned for `std::env::current_exe()` would be the symlink and not the underlying resolved path. This means that when the new binary is moved into position, it overrides the *symlink* rather than the original binary.

In Rust's stdlib docs for [`std::env::current_exe`], it reports that:

> If the executable was invoked through a symbolic link, some platforms
> will return the path of the symbolic link ...

Looking at the [macOS implementation] of `current_exe`, we can see that it calls [`libc::_NSGetExecutablePath`], and from the developer docs:

> Note that _NSGetExecutablePath() will return "a path" to the
> executable not a "real path" to the executable.  That is, the path may
> be a symbolic link and not the real file.

[`std::env::current_exe`]: https://doc.rust-lang.org/std/env/fn.current_exe.html#platform-specific-behavior
[macOS implementation]: https://github.com/rust-lang/rust/blob/249595b7523fc07a99c1adee90b1947739ca0e5b/library/std/src/sys/unix/os.rs#L384-L400
[`libc::_NSGetExecutablePath`]: https://developer.apple.com/library/archive/documentation/System/Conceptual/ManPages_iPhoneOS/man3/dyld.3.html

---

Thanks for this crate--it's exactly what I was after and the multi-platform support is greatly appreciated! 🎉 