### PR TITLE
Feature/update from content

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,14 @@ self_replace::self_replace(&new_binary)?;
 std::fs::remove_file(&new_binary)?;
 ```
 
+To update a binary with data from a remote source, use `self_replace_with`.
+
+```rust
+fn foo(new_binary_content: &[u8]) -> Result<()> {
+    self_replace::self_replace_with(new_binary_content)?;
+}
+```
+
 ## License and Links
 
 * [Documentation](https://docs.rs/self-replace/)

--- a/demo.bat
+++ b/demo.bat
@@ -18,6 +18,12 @@ echo Run replaces-itself.exe
 target\debug\examples\replaces-itself.exe
 
 echo.
+echo Run replaces-itself-with.exe
+target\debug\examples\replaces-itself-with.exe
+echo Run replaces-itself-with.exe
+target\debug\examples\replaces-itself-with.exe
+
+echo.
 echo Run deletes-itself-outside-path.exe
 target\debug\examples\deletes-itself-outside-path.exe
 if not exist target\debug\examples\NUL (

--- a/demo.sh
+++ b/demo.sh
@@ -18,6 +18,12 @@ echo "Run replaces-itself"
 target/debug/examples/replaces-itself
 
 echo
+echo "Run replaces-itself-with"
+target/debug/examples/replaces-itself-with
+echo "Run replaces-itself-with"
+target/debug/examples/replaces-itself-with
+
+echo
 echo "Run deletes-itself-outside-path"
 target/debug/examples/deletes-itself-outside-path
 

--- a/examples/replaces-itself-with.rs
+++ b/examples/replaces-itself-with.rs
@@ -1,0 +1,34 @@
+use std::fs::File;
+use std::io::Read;
+use std::path::PathBuf;
+
+fn load_executable(name: &PathBuf) -> &[u8] {
+    let mut f = File::open(name).unwrap();
+    let mut buf = Box::<Vec<u8>>::default();
+    f.read_to_end(&mut buf).unwrap();
+    Box::leak(buf)
+}
+
+use std::env::consts::EXE_EXTENSION;
+
+fn main() {
+    let exe = std::env::current_exe().unwrap();
+    let new_executable = std::fs::read_link(exe.clone())
+        .unwrap_or(exe)
+        .with_file_name("hello")
+        .with_extension(EXE_EXTENSION);
+
+    if !new_executable.is_file() {
+        eprintln!("hello does not exist, run cargo build --example hello first.");
+        std::process::exit(1);
+    }
+
+    let new_executable_content = load_executable(&new_executable);
+
+    println!("Next time I run, I am the hello executable");
+    self_replace::self_replace_with(new_executable_content).unwrap();
+
+    if std::env::var("FORCE_EXIT").ok().as_deref() == Some("1") {
+        std::process::exit(0);
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -192,3 +192,31 @@ pub fn self_replace<P: AsRef<Path>>(new_executable: P) -> Result<(), io::Error> 
         crate::windows::self_replace(new_executable.as_ref())
     }
 }
+
+/// Replaces the running executable with a different one.
+///
+/// This replaces the binary with another binary.  The provided buffer is written over the
+/// old executable.
+///
+/// ```
+/// # fn foo(new_binary_content: &[u8]) -> Result<(), std::io::Error> {
+/// self_replace::self_replace_with(new_binary_content)?;
+/// # Ok(()) }
+/// ```
+///
+/// Note that after this function concludes, the new executable is written to the
+/// old location, and the previous executable has been moved to a temporary alternative
+/// location.  This also means that if you want to manipulate that file further (for
+/// instance to change the permissions) you can do so.
+///
+/// By default the permissions of the original file are restored.
+pub fn self_replace_with<B: AsRef<[u8]>>(new_executable_content: B) -> Result<(), io::Error> {
+    #[cfg(unix)]
+    {
+        crate::unix::self_replace_with(new_executable_content.as_ref())
+    }
+    #[cfg(windows)]
+    {
+        crate::windows::self_replace_with(new_executable_content.as_ref())
+    }
+}

--- a/src/unix.rs
+++ b/src/unix.rs
@@ -2,7 +2,46 @@ use std::env;
 use std::fs;
 use std::io;
 use std::io::Write;
-use std::path::Path;
+use std::path::{Path, PathBuf};
+use tempfile::NamedTempFile;
+
+fn prepare_current_exe() -> Result<(NamedTempFile, fs::Permissions, PathBuf), io::Error> {
+    let mut exe = env::current_exe()?;
+    if fs::symlink_metadata(&exe).map_or(false, |x| x.file_type().is_symlink()) {
+        exe = fs::read_link(exe)?;
+    }
+    let old_permissions = exe.metadata()?.permissions();
+
+    let prefix = if let Some(hint) = exe.file_stem().and_then(|x| x.to_str()) {
+        format!(".{}.__temp__", hint)
+    } else {
+        ".__temp__".into()
+    };
+
+    Ok((
+        tempfile::Builder::new()
+            .prefix(&prefix)
+            .tempfile_in(exe.parent().ok_or_else(|| {
+                io::Error::new(
+                    io::ErrorKind::Other,
+                    "executable has no known parent folder",
+                )
+            })?)?,
+        old_permissions,
+        exe,
+    ))
+}
+
+fn finalize_updated_exe(tmp: NamedTempFile, exe: PathBuf) -> Result<(), io::Error> {
+    let (_, path) = tmp.keep()?;
+    match fs::rename(&path, exe) {
+        Ok(()) => Ok(()),
+        Err(err) => {
+            fs::remove_file(&path).ok();
+            Err(err)
+        }
+    }
+}
 
 /// On Unix a running executable can be safely deleted.
 pub fn self_delete() -> Result<(), io::Error> {
@@ -12,77 +51,25 @@ pub fn self_delete() -> Result<(), io::Error> {
 }
 
 pub fn self_replace(new_executable: &Path) -> Result<(), io::Error> {
-    let mut exe = env::current_exe()?;
-    if fs::symlink_metadata(&exe).map_or(false, |x| x.file_type().is_symlink()) {
-        exe = fs::read_link(exe)?;
-    }
-    let old_permissions = exe.metadata()?.permissions();
-
-    let prefix = if let Some(hint) = exe.file_stem().and_then(|x| x.to_str()) {
-        format!(".{}.__temp__", hint)
-    } else {
-        ".__temp__".into()
-    };
-
-    let tmp = tempfile::Builder::new()
-        .prefix(&prefix)
-        .tempfile_in(exe.parent().ok_or_else(|| {
-            io::Error::new(
-                io::ErrorKind::Other,
-                "executable has no known parent folder",
-            )
-        })?)?;
+    let (tmp, old_permissions, exe) = prepare_current_exe()?;
     fs::copy(new_executable, tmp.path())?;
     fs::set_permissions(tmp.path(), old_permissions)?;
 
     // if we made it this far, try to persist the temporary file and move it over.
-    let (_, path) = tmp.keep()?;
-    match fs::rename(&path, &exe) {
-        Ok(()) => {}
-        Err(err) => {
-            fs::remove_file(&path).ok();
-            return Err(err);
-        }
-    }
+    finalize_updated_exe(tmp, exe)?;
 
     Ok(())
 }
 
 pub fn self_replace_with(new_executable_content: &[u8]) -> Result<(), io::Error> {
-    let mut exe = env::current_exe()?;
-    if fs::symlink_metadata(&exe).map_or(false, |x| x.file_type().is_symlink()) {
-        exe = fs::read_link(exe)?;
-    }
-    let old_permissions = exe.metadata()?.permissions();
-
-    let prefix = if let Some(hint) = exe.file_stem().and_then(|x| x.to_str()) {
-        format!(".{}.__temp__", hint)
-    } else {
-        ".__temp__".into()
-    };
-
-    let tmp = tempfile::Builder::new()
-        .prefix(&prefix)
-        .tempfile_in(exe.parent().ok_or_else(|| {
-            io::Error::new(
-                io::ErrorKind::Other,
-                "executable has no known parent folder",
-            )
-        })?)?;
+    let (tmp, old_permissions, exe) = prepare_current_exe()?;
     let mut new_executable = fs::File::create(tmp.path())?;
     new_executable.write_all(new_executable_content)?;
     new_executable.flush()?;
     fs::set_permissions(tmp.path(), old_permissions)?;
 
     // if we made it this far, try to persist the temporary file and move it over.
-    let (_, path) = tmp.keep()?;
-    match fs::rename(&path, &exe) {
-        Ok(()) => {}
-        Err(err) => {
-            fs::remove_file(&path).ok();
-            return Err(err);
-        }
-    }
+    finalize_updated_exe(tmp, exe)?;
 
     Ok(())
 }

--- a/src/unix.rs
+++ b/src/unix.rs
@@ -1,6 +1,7 @@
 use std::env;
 use std::fs;
 use std::io;
+use std::io::Write;
 use std::path::Path;
 
 /// On Unix a running executable can be safely deleted.
@@ -32,6 +33,45 @@ pub fn self_replace(new_executable: &Path) -> Result<(), io::Error> {
             )
         })?)?;
     fs::copy(new_executable, tmp.path())?;
+    fs::set_permissions(tmp.path(), old_permissions)?;
+
+    // if we made it this far, try to persist the temporary file and move it over.
+    let (_, path) = tmp.keep()?;
+    match fs::rename(&path, &exe) {
+        Ok(()) => {}
+        Err(err) => {
+            fs::remove_file(&path).ok();
+            return Err(err);
+        }
+    }
+
+    Ok(())
+}
+
+pub fn self_replace_with(new_executable_content: &[u8]) -> Result<(), io::Error> {
+    let mut exe = env::current_exe()?;
+    if fs::symlink_metadata(&exe).map_or(false, |x| x.file_type().is_symlink()) {
+        exe = fs::read_link(exe)?;
+    }
+    let old_permissions = exe.metadata()?.permissions();
+
+    let prefix = if let Some(hint) = exe.file_stem().and_then(|x| x.to_str()) {
+        format!(".{}.__temp__", hint)
+    } else {
+        ".__temp__".into()
+    };
+
+    let tmp = tempfile::Builder::new()
+        .prefix(&prefix)
+        .tempfile_in(exe.parent().ok_or_else(|| {
+            io::Error::new(
+                io::ErrorKind::Other,
+                "executable has no known parent folder",
+            )
+        })?)?;
+    let mut new_executable = fs::File::create(tmp.path())?;
+    new_executable.write_all(new_executable_content)?;
+    new_executable.flush()?;
     fs::set_permissions(tmp.path(), old_permissions)?;
 
     // if we made it this far, try to persist the temporary file and move it over.

--- a/tests/test_examples.rs
+++ b/tests/test_examples.rs
@@ -257,3 +257,37 @@ fn test_self_replace_through_symlink() {
     fs::remove_dir_all(&workspace).unwrap();
     assert!(scratchspace.path().read_dir().unwrap().next().is_none());
 }
+
+#[test]
+fn test_self_replace_with() {
+    let scratchspace = tempfile::tempdir().unwrap();
+    let workspace = scratchspace.path().join("workspace");
+    fs::create_dir_all(&workspace).unwrap();
+
+    compile_example("replaces-itself-with");
+    compile_example("hello");
+
+    let exe = get_executable("replaces-itself-with", &workspace);
+    let hello = get_executable("hello", &workspace);
+
+    assert!(exe.is_file());
+    assert!(hello.is_file());
+
+    run(RunOptions {
+        path: &exe,
+        force_exit: true,
+        scratchspace: scratchspace.path(),
+        expected_output: "Next time I run, I am the hello executable",
+    });
+    assert!(exe.is_file());
+    assert!(hello.is_file());
+    run(RunOptions {
+        path: &exe,
+        force_exit: false,
+        scratchspace: scratchspace.path(),
+        expected_output: "Hello World!",
+    });
+
+    fs::remove_dir_all(&workspace).unwrap();
+    assert!(scratchspace.path().read_dir().unwrap().next().is_none());
+}


### PR DESCRIPTION
This simplifies applying updates from a remote source. 

Most of the time the updated executable comes from an outside source, in my case a database. 
It's more efficient to be able to call `self_replace_with(content)` instead of writing the new file content to a random temporary file on the filesystem and then call `self_replace(tmp_filename)` which  then copies the file to yet another temporary.

I took the liberty to refactor a bit to avoid code duplication due to my additions.