### PR TITLE
fix(test): drop serde_json dev-dependency to restore MSRV builds

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,3 @@ windows-sys = { version = "0.52", features = [
     "Win32_UI_Shell",
     "Win32_Security",
 ] }
-
-[dev-dependencies]
-serde_json = "1.0"

--- a/tests/test_examples.rs
+++ b/tests/test_examples.rs
@@ -7,6 +7,222 @@ use std::sync::{Once, RwLock};
 static BUILT_EXAMPLES_INIT: Once = Once::new();
 static BUILT_EXAMPLES: RwLock<Option<HashMap<String, PathBuf>>> = RwLock::new(None);
 
+/// Advances past any whitespace.
+fn skip_ws(bytes: &[u8], pos: &mut usize) {
+    while let Some(byte) = bytes.get(*pos) {
+        match byte {
+            b' ' | b'\t' | b'\n' | b'\r' => *pos += 1,
+            _ => break,
+        }
+    }
+}
+
+/// Advances past a quoted string, leaving `pos` right after the closing quote.
+fn skip_string(bytes: &[u8], pos: &mut usize) -> Option<()> {
+    if bytes.get(*pos) != Some(&b'"') {
+        return None;
+    }
+    *pos += 1;
+    loop {
+        match bytes.get(*pos) {
+            Some(b'\\') => *pos += 2,
+            Some(b'"') => {
+                *pos += 1;
+                return Some(());
+            }
+            Some(_) => *pos += 1,
+            None => return None,
+        }
+    }
+}
+
+/// Advances past an arbitrary JSON value, leaving `pos` right after it.
+fn skip_value(bytes: &[u8], pos: &mut usize) -> Option<()> {
+    match bytes.get(*pos)? {
+        b'"' => skip_string(bytes, pos),
+        b'{' | b'[' => {
+            let mut depth = 0usize;
+            loop {
+                match bytes.get(*pos)? {
+                    b'"' => skip_string(bytes, pos)?,
+                    b'{' | b'[' => {
+                        depth += 1;
+                        *pos += 1;
+                    }
+                    b'}' | b']' => {
+                        depth -= 1;
+                        *pos += 1;
+                        if depth == 0 {
+                            return Some(());
+                        }
+                    }
+                    _ => *pos += 1,
+                }
+            }
+        }
+        // numbers, `true`, `false` and `null` end at the next structural
+        // character or whitespace.
+        _ => {
+            while let Some(byte) = bytes.get(*pos) {
+                match byte {
+                    b',' | b'}' | b']' | b' ' | b'\t' | b'\n' | b'\r' => break,
+                    _ => *pos += 1,
+                }
+            }
+            Some(())
+        }
+    }
+}
+
+/// Returns the raw, still encoded value of a top-level key of a JSON object.
+///
+/// Nested objects and arrays are skipped over as a whole, so a key of the same
+/// name further down the document is never mistaken for the one looked for.
+fn json_field<'a>(obj: &'a str, key: &str) -> Option<&'a str> {
+    let bytes = obj.as_bytes();
+    let mut pos = 0;
+
+    skip_ws(bytes, &mut pos);
+    if bytes.get(pos) != Some(&b'{') {
+        return None;
+    }
+    pos += 1;
+
+    loop {
+        skip_ws(bytes, &mut pos);
+        match bytes.get(pos) {
+            Some(b',') => {
+                pos += 1;
+                continue;
+            }
+            Some(b'"') => {}
+            _ => return None,
+        }
+
+        let key_start = pos;
+        skip_string(bytes, &mut pos)?;
+        let this_key = obj.get(key_start + 1..pos - 1)?;
+
+        skip_ws(bytes, &mut pos);
+        if bytes.get(pos) != Some(&b':') {
+            return None;
+        }
+        pos += 1;
+        skip_ws(bytes, &mut pos);
+
+        let value_start = pos;
+        skip_value(bytes, &mut pos)?;
+        if this_key == key {
+            return obj.get(value_start..pos);
+        }
+    }
+}
+
+/// Reads four hex digits of a `\u` escape.
+fn json_hex4(chars: &mut std::str::Chars) -> Option<u32> {
+    let mut rv = 0u32;
+    for _ in 0..4 {
+        rv = rv * 16 + chars.next()?.to_digit(16)?;
+    }
+    Some(rv)
+}
+
+/// Decodes a raw JSON string value.
+///
+/// Returns `None` for anything that is not a well formed string, which
+/// includes the `null` that cargo emits for targets without an executable.
+fn json_string(raw: &str) -> Option<String> {
+    let bytes = raw.as_bytes();
+    if bytes.len() < 2 || bytes.first() != Some(&b'"') || bytes.last() != Some(&b'"') {
+        return None;
+    }
+
+    let mut rv = String::with_capacity(raw.len() - 2);
+    let mut chars = raw[1..raw.len() - 1].chars();
+    while let Some(c) = chars.next() {
+        if c != '\\' {
+            rv.push(c);
+            continue;
+        }
+        match chars.next()? {
+            '"' => rv.push('"'),
+            '\\' => rv.push('\\'),
+            '/' => rv.push('/'),
+            'b' => rv.push('\u{8}'),
+            'f' => rv.push('\u{c}'),
+            'n' => rv.push('\n'),
+            'r' => rv.push('\r'),
+            't' => rv.push('\t'),
+            'u' => match json_hex4(&mut chars)? {
+                high @ 0xd800..=0xdbff => {
+                    if chars.next()? != '\\' || chars.next()? != 'u' {
+                        return None;
+                    }
+                    let low = json_hex4(&mut chars)?;
+                    if !(0xdc00..=0xdfff).contains(&low) {
+                        return None;
+                    }
+                    rv.push(char::from_u32(
+                        0x10000 + ((high - 0xd800) << 10) + (low - 0xdc00),
+                    )?);
+                }
+                code => rv.push(char::from_u32(code)?),
+            },
+            _ => return None,
+        }
+    }
+
+    Some(rv)
+}
+
+/// Checks if a raw JSON array contains a given string.
+fn json_array_contains(raw: &str, needle: &str) -> bool {
+    let bytes = raw.as_bytes();
+    let mut pos = 0;
+
+    skip_ws(bytes, &mut pos);
+    if bytes.get(pos) != Some(&b'[') {
+        return false;
+    }
+    pos += 1;
+
+    loop {
+        skip_ws(bytes, &mut pos);
+        match bytes.get(pos) {
+            Some(b',') => {
+                pos += 1;
+                continue;
+            }
+            Some(b']') | None => return false,
+            _ => {}
+        }
+
+        let value_start = pos;
+        if skip_value(bytes, &mut pos).is_none() {
+            return false;
+        }
+        match raw.get(value_start..pos).and_then(json_string) {
+            Some(value) if value == needle => return true,
+            _ => {}
+        }
+    }
+}
+
+/// Picks the name and executable path of an example out of one of cargo's
+/// JSON artifact messages.
+///
+/// This deliberately does not use a JSON library: the crate would otherwise
+/// need a dev-dependency that has to be kept compatible with the MSRV.
+fn parse_example_artifact(line: &str) -> Option<(String, PathBuf)> {
+    let target = json_field(line, "target")?;
+    if !json_array_contains(json_field(target, "kind")?, "example") {
+        return None;
+    }
+    let name = json_string(json_field(target, "name")?)?;
+    let executable = json_string(json_field(line, "executable")?)?;
+    Some((name, PathBuf::from(executable)))
+}
+
 fn compile_examples() -> HashMap<String, PathBuf> {
     let mut cmd = Command::new("cargo");
     let output = cmd
@@ -25,34 +241,116 @@ fn compile_examples() -> HashMap<String, PathBuf> {
     let mut rv = HashMap::new();
 
     for line in String::from_utf8_lossy(&output.stdout).lines() {
-        let Ok(message) = serde_json::from_str::<serde_json::Value>(line) else {
-            continue;
-        };
-
-        let is_example = message
-            .get("target")
-            .and_then(|target| target.get("kind"))
-            .and_then(|kind| kind.as_array())
-            .map_or(false, |kinds| {
-                kinds.iter().any(|kind| kind.as_str() == Some("example"))
-            });
-
-        let built_name = message
-            .get("target")
-            .and_then(|target| target.get("name"))
-            .and_then(|name| name.as_str());
-
-        let executable = message.get("executable").and_then(|exe| exe.as_str());
-
-        if is_example && built_name.is_some() && executable.is_some() {
-            rv.insert(
-                built_name.unwrap().to_string(),
-                PathBuf::from(executable.unwrap()),
-            );
+        if let Some((name, executable)) = parse_example_artifact(line) {
+            rv.insert(name, executable);
         }
     }
 
     rv
+}
+
+#[test]
+fn test_parse_example_artifact() {
+    let line = r#"{"reason":"compiler-artifact","package_id":"path+file:///src#self-replace@1.5.0","manifest_path":"/src/Cargo.toml","target":{"kind":["example"],"crate_types":["bin"],"name":"hello","src_path":"/src/examples/hello.rs","edition":"2018","doc":false,"doctest":false,"test":false},"profile":{"opt_level":"0","debuginfo":2,"debug_assertions":true,"overflow_checks":true,"test":false},"features":[],"filenames":["/src/target/debug/examples/hello"],"executable":"/src/target/debug/examples/hello","fresh":false}"#;
+    assert_eq!(
+        parse_example_artifact(line),
+        Some((
+            "hello".to_string(),
+            PathBuf::from("/src/target/debug/examples/hello")
+        ))
+    );
+}
+
+#[test]
+fn test_parse_example_artifact_windows_path() {
+    let line = r#"{"reason":"compiler-artifact","target":{"kind":["example"],"name":"hello"},"executable":"C:\\src\\target\\debug\\examples\\hello.exe"}"#;
+    assert_eq!(
+        parse_example_artifact(line),
+        Some((
+            "hello".to_string(),
+            PathBuf::from("C:\\src\\target\\debug\\examples\\hello.exe")
+        ))
+    );
+}
+
+#[test]
+fn test_parse_example_artifact_skips_other_messages() {
+    // the library itself has no executable
+    let lib = r#"{"reason":"compiler-artifact","target":{"kind":["lib"],"name":"self-replace"},"executable":null}"#;
+    assert_eq!(parse_example_artifact(lib), None);
+
+    // build scripts do have one, but they are not examples
+    let build_script = r#"{"reason":"compiler-artifact","target":{"kind":["custom-build"],"name":"build-script-build"},"executable":"/src/target/debug/build/x/build-script-build"}"#;
+    assert_eq!(parse_example_artifact(build_script), None);
+
+    // and other message kinds have neither
+    let finished = r#"{"reason":"build-finished","success":true}"#;
+    assert_eq!(parse_example_artifact(finished), None);
+}
+
+#[test]
+fn test_parse_example_artifact_with_confusing_strings() {
+    // structural characters inside strings must not confuse the scanner
+    let line = r#"{"manifest_path":"/we{ird\"/\"executable\":\"nope\"/Cargo.toml","target":{"kind":["example"],"name":"hello"},"executable":"/we{ird/hello"}"#;
+    assert_eq!(
+        parse_example_artifact(line),
+        Some(("hello".to_string(), PathBuf::from("/we{ird/hello")))
+    );
+}
+
+#[test]
+fn test_parse_example_artifact_survives_garbage() {
+    for line in &[
+        "",
+        "not json at all",
+        "{",
+        r#"{"target":{"kind":["example"],"name":"hello"}"#,
+        r#"{"target":{"kind":["example"],"name":"hello"},"executable":}"#,
+        r#"{"target":{"kind":["example"],"name":"hello"},"executable":"unterminated}"#,
+    ] {
+        assert_eq!(parse_example_artifact(line), None);
+    }
+}
+
+#[test]
+fn test_parse_example_artifact_with_unexpected_types() {
+    // well formed JSON, but the fields are not shaped the way cargo shapes
+    // them.  None of these may parse into something or panic.
+    for line in &[
+        r#"{"target":null,"executable":"/src/target/debug/examples/hello"}"#,
+        r#"{"target":"hello","executable":"/src/target/debug/examples/hello"}"#,
+        r#"{"target":["example"],"executable":"/src/target/debug/examples/hello"}"#,
+        // `kind` is not an array
+        r#"{"target":{"kind":"example","name":"hello"},"executable":"/x/hello"}"#,
+        // `kind` holds no strings
+        r#"{"target":{"kind":[["example"]],"name":"hello"},"executable":"/x/hello"}"#,
+        // `name` is not a string
+        r#"{"target":{"kind":["example"],"name":42},"executable":"/x/hello"}"#,
+        // `executable` is not a string
+        r#"{"target":{"kind":["example"],"name":"hello"},"executable":42}"#,
+        r#"{"target":{"kind":["example"],"name":"hello"},"executable":["/x/hello"]}"#,
+        // the fields are missing altogether
+        r#"{"target":{"name":"hello"},"executable":"/x/hello"}"#,
+        r#"{"target":{"kind":["example"]},"executable":"/x/hello"}"#,
+        r#"{"target":{"kind":["example"],"name":"hello"}}"#,
+        r#"{}"#,
+    ] {
+        assert_eq!(parse_example_artifact(line), None);
+    }
+}
+
+#[test]
+fn test_json_string() {
+    assert_eq!(
+        json_string(r#""a\/b\nc\t\"d\"""#).as_deref(),
+        Some("a/b\nc\t\"d\"")
+    );
+    assert_eq!(
+        json_string(r#""\u00e9\ud83d\ude00""#).as_deref(),
+        Some("é😀")
+    );
+    assert_eq!(json_string("null"), None);
+    assert_eq!(json_string(r#""\ud800""#), None);
 }
 
 fn compile_example(name: &str) -> PathBuf {


### PR DESCRIPTION
## Problem

The `Tests` workflow is red on `main` (`d1356fd`). Only the MSRV jobs fail; the latest-stable jobs pass:

| Job | Result |
|---|---|
| Test on Latest Linux | ✅ |
| Test on Latest Windows | ✅ |
| Test on 1.63.0 Linux | ❌ exit 2 |
| Test on 1.63.0 macOS | ❌ exit 2 |
| Test on 1.63.0 Windows | ❌ exit 1 |

`d1356fd` ("fix(test): resolve example binaries from Cargo output") added a `serde_json` dev-dependency but did not update `Cargo.lock.msrv`. The MSRV jobs run `cp Cargo.lock.msrv Cargo.lock` and then `cargo test --all`, so cargo fills the gap by resolving the newest `serde_json` — 1.0.151, which declares `rust-version = "1.71"`:

```
error: package `serde_json v1.0.151` cannot be built because it requires
       rustc 1.71 or newer, while the currently active rustc version is 1.63.0
```

Reproduced locally on Rust 1.63.0 with the CI's own recipe.

The same commit also introduced a `let ... else`, which is Rust 1.65 or later. That would have failed the MSRV jobs immediately after the `serde_json` problem was solved.

## Fix

Pinning `serde_json` in `Cargo.lock.msrv` would work, but it means tracking the MSRV of `serde_json` plus `itoa`, `ryu` and `serde` from now on — the latest releases of all of those already require 1.68 or newer. Since the harness only needs three fields out of cargo's artifact messages, this scans them directly and drops the dependency again, leaving the crate with no dev-dependencies at all.

- `Cargo.toml`: remove the `[dev-dependencies] serde_json` section.
- `tests/test_examples.rs`: replace the `serde_json::Value` lookups with a small scanner (`json_field` / `json_string` / `json_array_contains` and a `skip_*` cursor) plus `parse_example_artifact`.

The behaviour `d1356fd` was after is preserved: example paths still come from cargo's `--message-format=json-render-diagnostics` output rather than being derived from the test executable's location, so custom build directories such as `CARGO_BUILD_BUILD_DIR` keep working. The `cargo build --examples` invocation, the `BUILT_EXAMPLES` cache, `compile_example()`'s signature and every existing test are untouched.

Two details the scanner gets right:

- It tracks nesting depth and string literals, so `json_field` only ever matches a **top-level** key — a key of the same name deeper in the message is never mistaken for it.
- It unescapes string values, which matters on Windows where `executable` arrives as `"C:\\src\\target\\debug\\examples\\hello.exe"`.

## Tests

Six unit tests are added for the scanner, covering a full real-world `compiler-artifact` line, escaped Windows paths, `"executable":null` and non-example targets, structural characters inside string values, malformed input, and the escape sequences (including `\uXXXX` surrogate pairs). They are pure functions, so they add no measurable runtime.

## Verification

- `cargo test --all` on stable — 13 tests + 5 doc-tests pass
- `make lint` (`cargo clippy --all -- -F clippy::dbg-macro -D warnings`) — clean
- `make format-check` — clean
- `./demo.sh` — exit 0
- **MSRV**: `cp Cargo.lock.msrv Cargo.lock && cargo test --all` on Rust **1.63.0** — 13 tests + 5 doc-tests pass (fails before this change)
- With `serde_json` gone, restoring `Cargo.lock.msrv` no longer pulls in anything new; the only remaining drift is the stale `self-replace` version entry (`1.4.0` vs `1.5.0`), which cargo rewrites harmlessly and which is left alone here.

## Note

Unrelated to this change: `test_self_delete_outside_path_force_exit` is flaky on Linux, failing intermittently with `ExecutableFileBusy` ("Text file busy") when a copied example is executed while another test thread holds a write handle. This reproduces on unmodified `d1356fd` and is not addressed here.